### PR TITLE
Custom submenu selector

### DIFF
--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -88,7 +88,7 @@
 		=============================================================*/
 		function menuSetup() {
 			menu.classList.remove( 'no-js' );
-			const submenuSelector = 'clickySubmenu' in menu.dataset ? menu.dataset.clickySubmenu : 'ul';
+			const submenuSelector = 'clickySubmenuSelector' in menu.dataset ? menu.dataset.clickySubmenuSelector : 'ul';
 
 			menu.querySelectorAll( submenuSelector ).forEach( ( submenu ) => {
 				const menuItem = submenu.parentElement;

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -6,29 +6,25 @@
  * 		- https://codepen.io/lottejackson/pen/yObQRM
  */
 
-(function() {
-
+( function() {
 	'use strict';
 
 	const ClickyMenus = function( menu ) {
-
 		// DOM element(s)
 		const container = menu.parentElement;
 		let currentMenuItem,
 			i,
 			len;
 
-		this.init = function( i ) {
-			menuSetup( i );
+		this.init = function() {
+			menuSetup();
 			document.addEventListener( 'click', closeOpenMenu );
-		}
-
+		};
 
 		/*===================================================
 		=            Menu Open / Close Functions            =
 		===================================================*/
 		function toggleOnMenuClick( e ) {
-
 			const button = e.currentTarget;
 
 			// close open menu if there is one
@@ -37,141 +33,113 @@
 			}
 
 			toggleSubmenu( button );
-
-		};
+		}
 
 		function toggleSubmenu( button ) {
-
 			const submenu = document.getElementById( button.getAttribute( 'aria-controls' ) );
 
 			if ( 'true' === button.getAttribute( 'aria-expanded' ) ) {
-
 				button.setAttribute( 'aria-expanded', false );
 				submenu.setAttribute( 'aria-hidden', true );
 				currentMenuItem = false;
-
 			} else {
-
 				button.setAttribute( 'aria-expanded', true );
 				submenu.setAttribute( 'aria-hidden', false );
 				preventOffScreenSubmenu( submenu );
 				currentMenuItem = button;
-
 			}
-
-		};
+		}
 
 		function preventOffScreenSubmenu( submenu ) {
-
 			const 	screenWidth =	window.innerWidth ||
 									document.documentElement.clientWidth ||
 									document.body.clientWidth,
-					parent = submenu.offsetParent,
-					menuLeftEdge = parent.getBoundingClientRect().left,
-					menuRightEdge = menuLeftEdge + submenu.offsetWidth;
+				parent = submenu.offsetParent,
+				menuLeftEdge = parent.getBoundingClientRect().left,
+				menuRightEdge = menuLeftEdge + submenu.offsetWidth;
 
 			if ( menuRightEdge + 32 > screenWidth ) { // adding 32 so it's not too close
 				submenu.classList.add( 'sub-menu--right' );
 			}
-
 		}
 
 		function closeOnEscKey( e ) {
-
-			if(	27 === e.keyCode ) {
-
+			if (	27 === e.keyCode ) {
 				// we're in a submenu item
-				if( null !== e.target.closest('ul[aria-hidden="false"]') ) {
+				if ( null !== e.target.closest( 'ul[aria-hidden="false"]' ) ) {
 					currentMenuItem.focus();
 					toggleSubmenu( currentMenuItem );
 
 				// we're on a parent item
-				} else if ( 'true' === e.target.getAttribute('aria-expanded') ) {
+				} else if ( 'true' === e.target.getAttribute( 'aria-expanded' ) ) {
 					toggleSubmenu( currentMenuItem );
 				}
-
 			}
-
 		}
 
 		function closeOpenMenu( e ) {
-
 			if ( currentMenuItem && ! e.target.closest( '#' + container.id ) ) {
 				toggleSubmenu( currentMenuItem );
 			}
-
-		};
+		}
 
 		/*===========================================================
 		=            Modify Menu Markup & Bind Listeners            =
 		=============================================================*/
-		function menuSetup( i ) {
+		function menuSetup() {
+			menu.classList.remove( 'no-js' );
+			const submenuSelector = 'clickySubmenu' in menu.dataset ? menu.dataset.clickySubmenu : 'ul';
 
-			menu.classList.remove('no-js');
-
-			/* if parent of menu has no ID, give it one */
-			if( menu.parentElement.id === '' ) {
-				menu.parentElement.id = 'clicky-menu-' + i;
-			}
-
-			menu.querySelectorAll('ul').forEach( ( submenu ) => {
-
+			menu.querySelectorAll( submenuSelector ).forEach( ( submenu ) => {
 				const menuItem = submenu.parentElement;
 
 				if ( 'undefined' !== typeof submenu ) {
+					const button = convertLinkToButton( menuItem );
 
-					let button = convertLinkToButton( menuItem );
-
-					setUpAria( submenu, button, i );
+					setUpAria( submenu, button );
 
 					// bind event listener to button
 					button.addEventListener( 'click', toggleOnMenuClick );
 					menu.addEventListener( 'keyup', closeOnEscKey );
-
 				}
-
-			});
-
-		};
+			} );
+		}
 
 		/**
 		 * Why do this? See https://justmarkup.com/articles/2019-01-21-the-link-to-button-enhancement/
+		 *
+		 * @param {HTMLElement} menuItem An element representing a link to be converted to a button
 		 */
 		function convertLinkToButton( menuItem ) {
+			const 	link = menuItem.getElementsByTagName( 'a' )[ 0 ],
+				linkHTML = link.innerHTML,
+				linkAtts = link.attributes,
+				button = document.createElement( 'button' );
 
-			const 	link = menuItem.getElementsByTagName( 'a' )[0],
-					linkHTML = link.innerHTML,
-					linkAtts = link.attributes,
-					button = document.createElement( 'button' );
-
-			if( null !== link ) {
-
+			if ( null !== link ) {
 				// copy button attributes and content from link
 				button.innerHTML = linkHTML.trim();
-				for( i = 0, len = linkAtts.length; i < len; i++ ) {
-					let attr = linkAtts[i];
-					if( 'href' !== attr.name ) {
+				for ( i = 0, len = linkAtts.length; i < len; i++ ) {
+					const attr = linkAtts[ i ];
+					if ( 'href' !== attr.name ) {
 						button.setAttribute( attr.name, attr.value );
 					}
 				}
 
 				menuItem.replaceChild( button, link );
-
 			}
 
 			return button;
-
 		}
 
-		function setUpAria( submenu, button, i ) {
-
+		function setUpAria( submenu, button ) {
 			const submenuId = submenu.getAttribute( 'id' );
 
 			let id;
-			if( null === submenuId ) {
-				id = button.textContent.trim().replace(/\s+/g, '-').toLowerCase() + '-submenu-' + i;
+			if ( null === submenuId ) {
+				id = button.textContent.trim().replace( /\s+/g, '-' ).toLowerCase() + '-submenu';
 			} else {
-				id = submenuId + '-submenu-' + i;
+				id = submenuId + '-submenu';
 			}
 
 			// set button ARIA
@@ -181,23 +149,16 @@
 			// set submenu ARIA
 			submenu.setAttribute( 'id', id );
 			submenu.setAttribute( 'aria-hidden', true );
-
 		}
-
-	}
+	};
 
 	/* Create a ClickMenus object and initiate menu for any menu with .clicky-menu class */
-	document.addEventListener('DOMContentLoaded', function(){
+	document.addEventListener( 'DOMContentLoaded', function() {
 		const menus = document.querySelectorAll( '.clicky-menu' );
-		let i = 1;
 
-		menus.forEach( menu => {
-
-			let clickyMenu = new ClickyMenus(menu);
-			clickyMenu.init(i);
-			i++;
-
-		});
-	});
-
-}());
+		menus.forEach( ( menu ) => {
+			const clickyMenu = new ClickyMenus( menu );
+			clickyMenu.init();
+		} );
+	} );
+}() );

--- a/readme.md
+++ b/readme.md
@@ -1,44 +1,50 @@
 # Clicky Menus
 
+Jump to: [About](#about), [Features](#features), [Setup](#setup), [Browser Support](#browser-support) [Changelog](#changelog)
+
+## About
+
 A project by Mark Root-Wiley, [MRW Web Design](https://MRWweb.com)
 
 Clicky Menus lets you create a progressively-enhanced, accessible one-level dropdown menu that opens when activated by click, touch, or `ENTER`/`SPACE`. The menu is progressively enhanced, supporting hover and keyboard navigation (in modern browsers) if JS is not enabled.
 
-## Basic Features
+Why should you want menus that work this way? Read the accompanying article on CSS Tricks, ["In Praise of the Unambiguous Click Menu"](https://css-tricks.com/in-praise-of-the-unambiguous-click-menu/).
 
-- Supports mouse, touch, and keyboard interactions
-- Turns parent items from links into buttons
-- `aria-expanded`, `aria-controls` and `aria-hidden` support
+## Features
+
+- Supports interaction with mouse, touch, and keyboard
+- Converts parent menu items from links into buttons
+- Automatic `aria-expanded`, `aria-controls` and `aria-hidden` support
 - Close open submenu with `ESC` key
 - Close open submenu with click outside of open menu
 - Basic offscreen-menu prevention
+- [Configure custom submenu selector](#custom-submenu-selector)
 
 ### Why only one level of submenu?
 
 This script only supports a single level of submenus, i.e., there are no "sub-sub-menus" or "tertiary menus". This is intentional because:
 
-1. I don't like them personally and think of them as a bit of a "navigation smell"—a la "code smell".
+1. I personally don't like them. They give off a bit of a "navigation smell"—_a la_ "code smell"—and can often be avoided for better results.
 2. This makes it very easy to make "mega menus" that can contain nested lists (basically permanently visible tertiary menus).
 
 If you really want this feature, there's an [open issue for sharing use cases](https://github.com/mrwweb/clicky-menus/issues/8). If you want to submit a pull request, please coordinate on that issue before doing any work!
 
-## Browser Support
+## Setup
 
-All Modern Browsers such as Firefox, Chrome, Edge, and Safari.
+1. Include `clicky-menus.js` anywhere in the DOM and `clicky-menus.css` in the `<head>`.
+2. Put the `clicky-menu` class on the top-level `<ul>` element containing your menu
 
-Internet Explorer 11 support is possible if you include polyfills for [`closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill) and [`NodeList.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Polyfill) and transpile your code with something like Babel.
-
-## Expected Markup
+### Expected Markup and Markup Transformation
 
 ```html
 <nav id="primary-nav"> <!-- element must have an ID -->
  <ul class="clicky-menu no-js">
   <li>
-   <a href="#">Menu Item 1</a>
+   <a href="#" class="a-custom-class">Parent Menu Item 1</a>
    <ul>
-    <li><a href="page-1a.html">Menu Item 1a</a></li>
-    <li><a href="page-1b.html">Menu Item 1b</a></li>
-    <li><a href="page-1c.html">Menu Item 1c</a></li>
+    <li><a href="page-1a.html">Submenu Item 1a</a></li>
+    <li><a href="page-1b.html">Submenu Item 1b</a></li>
+    <li><a href="page-1c.html">Submenu Item 1c</a></li>
    </ul>
   </li>
   <--! etc… -->
@@ -46,12 +52,56 @@ Internet Explorer 11 support is possible if you include polyfills for [`closest`
 </nav>
 ```
 
-## Setup
+Once the script runs, the markup is changed to:
 
-Include `clicky-menus.js` anywhere in the DOM and `clicky-menus.css` in the `<head>`.
+```html
+<nav id="primary-nav"> <!-- element must have an ID -->
+ <ul class="clicky-menu no-js">
+  <li>
+   <button aria-expanded="false" aria-controls="parent-menu-item-1-submenu" class="a-custom-class">Parent Menu Item 1</button>
+   <ul id="parent-menu-item-1-submenu" aria-hidden="true">
+    <li><a href="page-1a.html">Submenu Item 1a</a></li>
+    <li><a href="page-1b.html">Submenu Item 1b</a></li>
+    <li><a href="page-1c.html">Submenu Item 1c</a></li>
+   </ul>
+  </li>
+  <--! etc… -->
+ </ul>
+</nav>
+```
+
+#### Notes on Markup Transformation
+
+- All attributes on links converted to buttons are retained except for `href`.
+- All elements inside links converted to buttons, such as an SVG icon, are retained in the button.
+- When a user clicks a submenu toggle button (i.e., parent menu item), `aria-expanded` and `aria-hidden` are appropriately toggled between `true` and `false`.
+
+### Custom Submenu Selector
+
+If you have unusual markup or design requirements, you can set a custom selector for the submenu element with a `data-clicky-submenu-selector` attribute on the top-level `<ul>` element (the same one with the `clicky-menu` class).
+
+For example, if you only want to select the first level of nested `<ul>` elements while building a megamenu, you would do:
+
+```html
+<ul class="clicky-menu" data-clicky-submenu-selector=".clicky-menu > li > ul">
+    <!-- menu items -->
+</ul>
+```
+
+## Browser Support
+
+All Modern Browsers such as Firefox, Chrome, Edge, and Safari.
+
+Internet Explorer 11 support is possible if you include polyfills for [`closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill) and [`NodeList.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Polyfill) and transpile your code with something like Babel.
 
 ## Changelog
 
-### 1.0.0
+### 1.1.0 (October 19, 2023)
+
+- Add support for [data attribute that sets custom submenu selector](#custom-submenu-selector)
+- Fix mismatched variable name leading to broken submenu IDs
+- Improve documentation in the readme
+
+### 1.0.0 (March 15, 2021)
 
 - It's alive!


### PR DESCRIPTION
## Add Custom Submenu Selector configured via a data attribute

If you have unusual markup or design requirements, you can set a custom selector for the submenu element with a `data-clicky-submenu-selector` attribute on the top-level `<ul>` element (the same one with the `clicky-menu` class).

For example, if you only want to select the first level of nested `<ul>` elements while building a megamenu, you would do:

```html
<ul class="clicky-menu" data-clicky-submenu-selector=".clicky-menu > li > ul">
    <!-- menu items -->
</ul>
```

Closes #1 