### PR TITLE
V1.3.0

### DIFF
--- a/clicky-menus.css
+++ b/clicky-menus.css
@@ -1,5 +1,5 @@
 /**
- * Clicky Menus v1.2.0
+ * Clicky Menus v1.3.0
  */
 
 /**

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -9,7 +9,7 @@
 		// DOM element(s)
 		const container = menu.parentElement;
 		let currentMenuItem,
-			i,
+			i = 0,
 			len;
 
 		this.init = function() {
@@ -62,7 +62,7 @@
 		}
 
 		function closeOnEscKey( e ) {
-			if (	27 === e.keyCode ) {
+			if ( 27 === e.keyCode ) {
 				// we're in a submenu item
 				if ( null !== e.target.closest( 'ul[aria-hidden="false"]' ) ) {
 					currentMenuItem.focus();
@@ -117,14 +117,14 @@
 		 */
 		function convertLinkToButton( menuItem ) {
 			const 	link = menuItem.getElementsByTagName( 'a' )[ 0 ],
-				linkHTML = link.innerHTML,
-				linkAtts = link.attributes,
-				button = document.createElement( 'button' );
+					linkHTML = link.innerHTML,
+					linkAtts = link.attributes,
+					button = document.createElement( 'button' );
 
 			if ( null !== link ) {
 				// copy button attributes and content from link
 				button.innerHTML = linkHTML.trim();
-				for ( i = 0, len = linkAtts.length; i < len; i++ ) {
+				for ( len = linkAtts.length; i < len; i++ ) {
 					const attr = linkAtts[ i ];
 					if ( 'href' !== attr.name ) {
 						button.setAttribute( attr.name, attr.value );

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -67,10 +67,11 @@
 				if ( null !== e.target.closest( 'ul[aria-hidden="false"]' ) ) {
 					currentMenuItem.focus();
 					toggleSubmenu( currentMenuItem );
-
+					e.stopPropagation();
 				// we're on a parent item
 				} else if ( 'true' === e.target.getAttribute( 'aria-expanded' ) ) {
 					toggleSubmenu( currentMenuItem );
+					e.stopPropagation();
 				}
 			}
 		}

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -168,4 +168,19 @@
 			clickyMenu.init();
 		} );
 	} );
+
+	function dispatchMenuClose(e) {
+		const menuId = e.currentTarget.getAttribute('data-clicky-menus-close');
+		const menu = document.getElementById( menuId );
+		if( menu ) {
+			menu.dispatchEvent( new Event( 'clickyMenusClose' ) );
+		}
+	}
+
+	const menuClosers = document.querySelectorAll( '[data-clicky-menus-close]' );
+	if( menuClosers ) {
+		menuClosers.forEach( ( menuCloser ) => {
+			menuCloser.addEventListener( 'click', dispatchMenuClose );
+		} );
+	}
 }() );

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -142,9 +142,11 @@
 
 			let id;
 			if ( null === submenuId ) {
-				id = button.textContent.trim().replace( /\s+/g, '-' ).toLowerCase() + '-submenu';
+				id = button.textContent.trim().replace( /\s+/g, '-' ).replace(/^[^a-zA-Z]+|[^\w:.-]+/g, "").toLowerCase() + `-submenu-${i}`;
+				i++;
 			} else {
-				id = submenuId + '-submenu';
+				id = `${submenuId}-submenu-${i}`;
+				i++;
 			}
 
 			// set button ARIA

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -1,5 +1,5 @@
 /**
- * Clicky Menus v1.2.0
+ * Clicky Menus v1.3.0
  */
 
 ( function() {

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,23 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
 	<meta charset="UTF-8">
 	<title>Click Menus Demo</title>
 	<script src="../clicky-menus.js"></script>
 	<link rel="stylesheet" href="demo.css" />
 	<link rel="stylesheet" href="../clicky-menus.css" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
+
 <body>
 	<!-- for use with <use> -->
-	<svg xmlns="http://www.w3.org/2000/svg"  hidden>
-		<symbol id="arrow" viewbox="0 0 16 16" >
+	<svg xmlns="http://www.w3.org/2000/svg" hidden>
+		<symbol id="arrow" viewbox="0 0 16 16">
 			<polyline points="4 6, 8 10, 12 6" stroke="#000" stroke-width="2" fill="transparent" stroke-linecap="round" />
 		</symbol>
 	</svg>
 
 	<!-- In the real world, all hrefs would have go to real, unique URLs, not a "#" -->
 	<nav id="site-navigation" class="site-navigation" aria-label="Clickable Menu Demonstration">
-		<ul class="main-menu clicky-menu no-js">
+		<ul id="main-menu" class="main-menu clicky-menu no-js">
 			<li>
 				<a href="#">Home</a>
 			</li>
@@ -61,9 +64,11 @@
 					<li><a href="#">Mission</a></li>
 					<li><a href="#">History</a></li>
 					<li><a href="#">Contact</a></li>
+					<li><button data-clicky-menus-close="main-menu">Close Submenu</button></li>
 				</ul>
 			</li>
 		</ul>
 	</nav>
 </body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clicky-menus",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "homepage": "https://github.com/mrwweb/clicky-menus#readme",
   "description": "Simple click-triggered navigation submenus. Accessible and progressively enhanced.",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Clicky Menus
 
-Version 1.2.0
+Version 1.3.0
 
 Jump to: [About](#about), [Features](#features), [Setup & Configuration](#setup--configuration), [Browser Support](#browser-support) [Changelog](#changelog)
 
@@ -25,7 +25,7 @@ Why should you want menus that work this way? Read the accompanying article on C
 - Close open submenu with click outside of open menu
 - Basic offscreen-menu prevention
 - [Configure custom submenu selector](#custom-submenu-selector)
-- [Programmatically close open submenus](#closing-submenus-with-js)
+- [Close open submenus with a button](#closing-open-submenus-with-data-attribute-or-custom-javascript-event)
 
 ### Why only one level of submenu?
 
@@ -74,13 +74,21 @@ For example, if you only want to only select the first level of nested `<ul>` el
 </ul>
 ```
 
-### Closing submenus with JS
+### Closing open submenus with data attribute or custom JavaScript event
 
 There are a variety of situations where you might want to force submenus to close based on interactions elsewhere on the page. For example, maybe an adjacent search toggle overlaps with submenus when expanded.
 
 To close all open submenus, dispatch the custom event `clickyMenusClose` to the `.clicky-menu` DOM node (usually the `<ul>` containing menu items).
 
-Example:
+#### With data attribute
+
+Where `my-menu` is the ID of the menu you want to close and is the element with the `clicky-menu` class:
+
+```html
+<button data-clicky-menus-close="my-menu">Close Open Submenus</button>
+```
+
+#### With custom JavaScript event
 
 ```html
 <button id="close-open-submenus">Close Open Submenus</button>
@@ -146,6 +154,12 @@ All Modern Browsers such as Firefox, Chrome, Edge, and Safari.
 Internet Explorer 11 support is possible if you include polyfills for [`closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill) and [`NodeList.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Polyfill) and transpile your code with something like Babel.
 
 ## Changelog
+
+### 1.3.0 (April 25, 2025)
+
+- NEW! Use the `data-clicky-menus-close` attribute on any element to automatically close the open submenu. It should be set to the ID of the element with the `clicky-menu` class. Fixes #21.
+- Don't let `ESC` propogate when pressed on an item inside a submenu. This should generally prevent dialogs and other toggle features from closing when they contain a menu. Fixes #22
+- Stripe special characters from automatically generated submenu IDs and add an increment (e.g. `-1`) to the end of each ID to get much closer to guaranteeing it is unique. Fixes #12
 
 ### 1.2.0 (May 21, 2024)
 

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ Internet Explorer 11 support is possible if you include polyfills for [`closest`
 
 - NEW! Use the `data-clicky-menus-close` attribute on any element to automatically close the open submenu. It should be set to the ID of the element with the `clicky-menu` class. Fixes #21.
 - Don't let `ESC` propogate when pressed on an item inside a submenu. This should generally prevent dialogs and other toggle features from closing when they contain a menu. Fixes #22
-- Stripe special characters from automatically generated submenu IDs and add an increment (e.g. `-1`) to the end of each ID to get much closer to guaranteeing it is unique. Fixes #12
+- Strip special characters from automatically generated submenu IDs and add an increment (e.g. `-1`) to the end of each ID to get much closer to guaranteeing it is unique. Fixes #12
 
 ### 1.2.0 (May 21, 2024)
 


### PR DESCRIPTION
- NEW! Use the `data-clicky-menus-close` attribute on any element to automatically close the open submenu. It should be set to the ID of the element with the `clicky-menu` class. Fixes #21.
- Don't let `ESC` propogate when pressed on an item inside a submenu. This should generally prevent dialogs and other toggle features from closing when they contain a menu. Fixes #22
- Strip special characters from automatically generated submenu IDs and add an increment (e.g. `-1`) to the end of each ID to get much closer to guaranteeing it is unique. Fixes #12