### PR TITLE
Issues/27 button classes

### DIFF
--- a/clicky-menus.css
+++ b/clicky-menus.css
@@ -1,5 +1,5 @@
 /**
- * Clicky Menus v1.5.0
+ * Clicky Menus v1.5.2
  */
 
 /**

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -1,5 +1,5 @@
 /**
- * Clicky Menus v1.5.0
+ * Clicky Menus v1.5.2
  */
 
 ( function() {

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -160,6 +160,14 @@
 		}
 	};
 
+	function dispatchMenuClose(e) {
+		const menuId = e.currentTarget.getAttribute('data-clicky-menus-close');
+		const menu = document.getElementById( menuId );
+		if( menu ) {
+			menu.dispatchEvent( new Event( 'clickyMenusClose' ) );
+		}
+	}
+
 	/* Create a ClickMenus object and initiate menu for any menu with .clicky-menu class */
 	document.addEventListener( 'DOMContentLoaded', function() {
 		const menus = document.querySelectorAll( '.clicky-menu' );
@@ -169,20 +177,12 @@
 			clickyMenu.init();
 			i++;
 		} );
-	} );
 
-	function dispatchMenuClose(e) {
-		const menuId = e.currentTarget.getAttribute('data-clicky-menus-close');
-		const menu = document.getElementById( menuId );
-		if( menu ) {
-			menu.dispatchEvent( new Event( 'clickyMenusClose' ) );
+		const menuClosers = document.querySelectorAll( '[data-clicky-menus-close]' );
+		if( menuClosers ) {
+			menuClosers.forEach( ( menuCloser ) => {
+				menuCloser.addEventListener( 'click', dispatchMenuClose );
+			} );
 		}
-	}
-
-	const menuClosers = document.querySelectorAll( '[data-clicky-menus-close]' );
-	if( menuClosers ) {
-		menuClosers.forEach( ( menuCloser ) => {
-			menuCloser.addEventListener( 'click', dispatchMenuClose );
-		} );
-	}
+	} );
 }() );

--- a/clicky-menus.js
+++ b/clicky-menus.js
@@ -9,7 +9,7 @@
 		// DOM element(s)
 		const container = menu.parentElement;
 		let currentMenuItem,
-			i = 0,
+			i,
 			len;
 
 		this.init = function() {
@@ -124,7 +124,7 @@
 			if ( null !== link ) {
 				// copy button attributes and content from link
 				button.innerHTML = linkHTML.trim();
-				for ( len = linkAtts.length; i < len; i++ ) {
+				for ( i = 0, len = linkAtts.length; i < len; i++ ) {
 					const attr = linkAtts[ i ];
 					if ( 'href' !== attr.name ) {
 						button.setAttribute( attr.name, attr.value );

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -40,7 +40,7 @@
 				</ul>
 			</li>
 			<li>
-				<a href="#">
+				<a href="#" class="test">
 					Portfolio
 					<svg aria-hidden="true" width="16" height="16">
 						<use xlink:href="#arrow" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clicky-menus",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "homepage": "https://github.com/mrwweb/clicky-menus#readme",
   "description": "Simple click-triggered navigation submenus. Accessible and progressively enhanced.",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Clicky Menus
 
-Version 1.5.0
+Version 1.5.2
 
 Jump to: [About](#about), [Features](#features), [Setup & Configuration](#setup--configuration), [Browser Support](#browser-support) [Changelog](#changelog)
 
@@ -158,7 +158,12 @@ Internet Explorer 11 support is possible if you include polyfills for [`closest`
 
 ## Changelog
 
-### 1.5.0 (May 27, 2025)
+### 1.5.2 (October 30, 2025)
+
+- Resolve issue since 1.2.0 where replaced parent link attributes were not correctly transfered to the button
+- Make sure scripts works fully when loaded in the `<head>`
+
+### 1.5.0 /  1.5.1 (May 27, 2025)
 
 - Change `ESC` key event handler to fire on `keydown` instead of `keyup` and use `.preventDefault()` instead of `.stopPropogation()` when focus is inside a submenu or parent of open submenu. This will prevent the `ESC` key from closing `dialog` elements when a clicky-menu is inside one.
 - Note: v1.5.1 is identical to v1.5.0. Published to NPM to ensure latest version is used after adding v1.4.0 and v1.3.0 to NPM registry.

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ Internet Explorer 11 support is possible if you include polyfills for [`closest`
 
 ### 1.5.2 (October 30, 2025)
 
-- Resolve issue since 1.2.0 where replaced parent link attributes were not correctly transfered to the button
+- Resolve issue since 1.2.0 where replaced parent link attributes were not correctly transfered to the button. Closes #27
 - Make sure scripts works fully when loaded in the `<head>`
 
 ### 1.5.0 /  1.5.1 (May 27, 2025)


### PR DESCRIPTION
- Resolve issue since 1.2.0 where replaced parent link attributes were not correctly transfered to the button. Closes #27
- Make sure scripts works fully when loaded in the `<head>`